### PR TITLE
Support for Markdown with django >= 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django
+django-markdown>=0.8.4

--- a/wikisyntax/markdown.py
+++ b/wikisyntax/markdown.py
@@ -1,4 +1,7 @@
-from django.contrib.markup.templatetags.markup import markdown
+try:
+    from django.contrib.markup.templatetags.markup import markdown # Django 1.4
+except ImportError:
+    from django_markdown.templatetags.django_markdown import markdown # Django >= 1.6
 from django.utils.safestring import mark_safe
 from .constants import LEFTBRACKET, RIGHTBRACKET
 


### PR DESCRIPTION
Added support for django >= 1.6 with use of third party requirement django-markdown